### PR TITLE
LIBERAITDC-194 Updated dropbox event filter 

### DIFF
--- a/lasp_opensearch_data_center/constructs/backend_storage.py
+++ b/lasp_opensearch_data_center/constructs/backend_storage.py
@@ -10,6 +10,8 @@ from aws_cdk import (
     aws_s3_notifications as s3_notify,
 )
 
+from aws_cdk.aws_s3 import NotificationKeyFilter
+
 
 class BackendStorageConstruct(Construct):
     """Construct containing standard resources used by the data center back end, including notification mechanisms
@@ -102,7 +104,8 @@ class BackendStorageConstruct(Construct):
         # Send files from dropbox bucket into SQS
         self.dropbox_bucket.add_event_notification(
             s3.EventType.OBJECT_CREATED,
-            s3_notify.SqsDestination(self.dropbox_queue)
+            s3_notify.SqsDestination(self.dropbox_queue),
+            s3.NotificationKeyFilter(prefix="received_files/")
         )
 
         # Create DLQ


### PR DESCRIPTION
This PR adds an event filter to the dropbox bucket, so now you must copy your files to s3://briandev-liberaitdc-dropbox/received_files/ to get them to ingest